### PR TITLE
Fix PHP Fatal in Help.php

### DIFF
--- a/Classes/Command/Help.php
+++ b/Classes/Command/Help.php
@@ -59,7 +59,7 @@ class Help extends \Library\IRC\Command\Base
                 if (trim(ucfirst(strtolower($command))) == $name)
                 {
 		    // We found it!
-                    if (empty($details->getHelp()))
+                    if (!$details->getHelp())
                     {
                         // But it doesn't have any help... :(
                         $this->say('No help available for command ' . $name);


### PR DESCRIPTION
I cloned a fresh clone of this repository, changed config.php, renamed it to config.local.php. Seems fine, until you run "php phpbot404.php", because I got this: PHP Fatal error: Can't use method return value in write context in ./Classes/Command/Help.php on line 62

This patch should fix it.