### PR TITLE
Major changes. BEWARE: HERE BE DRAGONS!

### DIFF
--- a/Classes/Command/Help.php
+++ b/Classes/Command/Help.php
@@ -32,7 +32,7 @@ class Help extends \Library\IRC\Command\Base
         $command = (!empty($this->arguments[0]) ? preg_replace('/\s\s+/', '', $this->arguments[0]) : '');
         
         // Get all available commands.
-        $commands = $this->bot->getCommands();
+        $commands = $this->bot->commandManager->listCommands();
         
         // Does this user have privileges?
         $view_all = $this->verifyUser();
@@ -51,7 +51,7 @@ class Help extends \Library\IRC\Command\Base
         else
         {
             // Get all commands.
-            $commands = $this->bot->getCommands();
+            $commands = $this->bot->commandManager->listCommands();
             
             // Loop through each to get the one we need.
             foreach ($commands as $name => $details)
@@ -59,7 +59,7 @@ class Help extends \Library\IRC\Command\Base
                 if (trim(ucfirst(strtolower($command))) == $name)
                 {
 		    // We found it!
-                    if (empty($details->getHelp()))
+                    if (!$details->getHelp())
                     {
                         // But it doesn't have any help... :(
                         $this->say('No help available for command ' . $name);

--- a/Classes/Command/Imdb.php
+++ b/Classes/Command/Imdb.php
@@ -57,7 +57,7 @@ class Imdb extends \Library\IRC\Command\Base {
         }
 
         $apiUri  = sprintf($this->apiUri, $imdbTitle);
-        $getJson = $this->fetch($apiUri);
+        $getJson = \Library\FunctionCollection::fetch($apiUri);
 
         $json = json_decode($getJson, true);
 

--- a/Classes/Command/Join.php
+++ b/Classes/Command/Join.php
@@ -32,7 +32,7 @@ class Join extends \Library\IRC\Command\Base {
      *
      * @var integer
      */
-    protected $numberOfArguments = 1;
+    protected $numberOfArguments = array(1, 2);
     
     /**
      * Verify the user before executing this command.
@@ -47,7 +47,8 @@ class Join extends \Library\IRC\Command\Base {
      * IRC-Syntax: JOIN [#channel]
      */
     public function command() {
-        $this->connection->sendData('JOIN '.$this->arguments[0]);
+        
+        $this->connection->sendData('JOIN '.$this->arguments[0] . (!empty($this->arguments[1]) ? ' ' . $this->arguments[1] : ''));
     }
 }
 ?>

--- a/Classes/Library/FunctionCollection.php
+++ b/Classes/Library/FunctionCollection.php
@@ -41,6 +41,30 @@
         public static function removeLineBreaks( $string ) {
             return str_replace( array ( chr( 10 ), chr( 13 ) ), '', $string );
         }
+        /**
+         * Returns class name of $object without namespace
+         *
+         * @param mixed $object
+         * @author Matej Velikonja <matej@velikonja.si>
+         * @return string
+         */
+        public static function getClassName( $object) {
+            $objectName = explode( '\\', get_class( $object ) );
+            $objectName = $objectName[count( $objectName ) - 1];
+    
+            return $objectName;
+        }
+        
+        public static function getUserNickName($data) {
+            $result = preg_match('/:([a-zA-Z0-9_]+)!/', $data, $matches);
+    
+            if ($result !== false) {
+                if (!empty($matches[1]))
+                    return $matches[1];
+            }
+    
+            return false;
+        }
 
     }
 ?>

--- a/Classes/Library/FunctionCollection.php
+++ b/Classes/Library/FunctionCollection.php
@@ -65,6 +65,40 @@
     
             return false;
         }
+        
+        /**
+         * Fetches data from $uri
+         *
+         * @param string $uri
+         * @return string
+         */
+        public static function fetch($uri) {
+    
+            $this->bot->log("Fetching data from URI: " . $uri);
+    
+            // create curl resource
+            $ch = curl_init();
+    
+            // set url
+            curl_setopt($ch, CURLOPT_URL, $uri);
+            
+            // user agent.
+            curl_setopt($ch, CURLOPT_USERAGENT, 'WildPHP/IRCBot');
+    
+            //return the transfer as a string
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+            curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1);
+    
+            // $output contains the output string
+            $output = curl_exec($ch);
+    
+            // close curl resource to free up system resources
+            curl_close($ch);
+    
+            //$this->bot->log("Data fetched: " . $output);
+    
+            return $output;
+        }
 
     }
 ?>

--- a/Classes/Library/FunctionCollection.php
+++ b/Classes/Library/FunctionCollection.php
@@ -73,9 +73,6 @@
          * @return string
          */
         public static function fetch($uri) {
-    
-            $this->bot->log("Fetching data from URI: " . $uri);
-    
             // create curl resource
             $ch = curl_init();
     

--- a/Classes/Library/IRC/Bot.php
+++ b/Classes/Library/IRC/Bot.php
@@ -71,16 +71,15 @@ class Bot {
     
     /**
      * The current log object; usually an instance of LogManager.
-     * @var object
+     * @var \Library\IRC\Log
      */
     public $log;
-
+    
     /**
-     * Complete file path to the log file.
-     * Configure the path, the filename is generated and added.
+     * The source of the data.
      * @var string
      */
-    private $logFile = '';
+    public $source = '';
 
     /**
      * Defines the prefix for all commands interacting with the bot.
@@ -404,28 +403,24 @@ class Bot {
     }
     
     /**
-     * Setup the LogManager instance pointed at.
-     * @param object $log The LogManager instance.
+     * Returns the current command prefix.
      */
-    public function setupLogging($log)
-    {
-
-    }
-
-    public function getCommands() {
-        return $this->commands;
-    }
-
     public function getCommandPrefix() {
         return $this->commandPrefix;
     }
     
+    /**
+     * Returns the current connection.
+     */
     public function getConnection()
     {
 	return $this->connection;
     }
     
-    // Called on shutdown of the bot; doesn't shut it down!
+    /**
+     * Handles closing log files and, if needed, flushing buffers.
+     * Called at shutdown.
+     */
     public function onShutdown()
     {	
     	// It is possible that we have not had a chance to create a log object yet.

--- a/Classes/Library/IRC/Bot.php
+++ b/Classes/Library/IRC/Bot.php
@@ -165,7 +165,7 @@ class Bot {
         $this->setMaxReconnects( $configuration['max_reconnects'] );
 	
 	// Set the command prefix.
-	$this->setCommandPrefix($configuration['command_prefix']);
+	$this->setCommandPrefix($configuration['prefix']);
     }
     
     /**

--- a/Classes/Library/IRC/Command/Base.php
+++ b/Classes/Library/IRC/Command/Base.php
@@ -247,39 +247,5 @@
 
             return null;
         }
-
-        /**
-         * Fetches data from $uri
-         *
-         * @param string $uri
-         * @return string
-         */
-        protected function fetch($uri) {
-
-            $this->bot->log("Fetching data from URI: " . $uri);
-
-            // create curl resource
-            $ch = curl_init();
-
-            // set url
-            curl_setopt($ch, CURLOPT_URL, $uri);
-            
-            // user agent.
-            curl_setopt($ch, CURLOPT_USERAGENT, 'WildPHP/IRCBot');
-
-            //return the transfer as a string
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-            curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1);
-
-            // $output contains the output string
-            $output = curl_exec($ch);
-
-            // close curl resource to free up system resources
-            curl_close($ch);
-
-            //$this->bot->log("Data fetched: " . $output);
-
-            return $output;
-        }
     }
 ?>

--- a/Classes/Library/IRC/Command/Base.php
+++ b/Classes/Library/IRC/Command/Base.php
@@ -59,7 +59,14 @@
          *
          * @var string
          */
-        private $data;
+        protected $data;
+        
+        /**
+         * Whether the command needs to verify the user is a bot owner.
+         *
+         * @var bool
+         */
+        protected $verify = false;
 
         /**
          * The number of arguments the command needs.
@@ -71,7 +78,7 @@
         protected $numberOfArguments = 0;
         
         /**
-         * The help string, shown to the user when using the help command.
+         * The help string, shown to the user when using the !help command.
          *
          * This is optional to define in the command, but it is recommended you do.
          *
@@ -87,18 +94,6 @@
          * @var string
          */
         protected $usage = '';
-        
-        /**
-         * Verify the user before executing a command.
-         *
-         * Defaults to false to allow everyone to execute commands
-         * which do not have this flag set.
-         *
-         * This is optional to define in the command.
-         *
-         * @var bool
-         */
-        protected $verify = false;
 
         /**
          * Executes the command.
@@ -108,6 +103,8 @@
          * @param string          $data      Original data from server
          */
         public function executeCommand( array $arguments, $source, $data ) {
+            global $config;
+            
             // Set source
             $this->source = $source;
 
@@ -142,7 +139,7 @@
             {
                 if (!((in_array(count($arguments), $this->numberOfArguments)) || (in_array(-1, $this->numberOfArguments) && count($arguments) >= 1)))
                 {
-                    $this->say('Error: illegal amount of arguments. For help, use' . $this->bot->commandPrefix . 'help ' . str_replace('Command\\', '', get_class($this)));
+                    $this->say('Error: illegal amount of arguments. For help, use ' . $this->bot->commandPrefix . 'help ' . str_replace('Command\\', '', get_class($this)));
                     return;
                 }
             }
@@ -161,7 +158,7 @@
             // Execute the command.
             $this->command();
         }
-        
+
         /**
          * Checks the legitimacy of the user running a command.
          *
@@ -170,11 +167,11 @@
         {
             global $config;
             // Get the host.
-            preg_match("/~([^\s]++)++/", $this->data, $hosts);
+            preg_match("/!([^\s]+)/", $this->data, $hosts);
             
             // Check if the user has privileges.
-            $this->bot->log('Requesting privileges for host ' . $hosts[0] . '...');
-            if (!in_array($hosts[0], $config['hosts']))
+            $this->bot->log('Requesting privileges for host ' . $hosts[1] . '...');
+            if (!in_array($hosts[1], $config['hosts']))
             {
                 // Nope. No access for you.
                 $this->bot->log('Failed; this host is not trusted.');
@@ -183,29 +180,23 @@
             else
                 return true;
         }
-
+       
         /**
          * Sends PRIVMSG to source with $msg
          *
          * @param string $msg
          */
        protected function say($msg) {
-            $this->connection->sendData(
-                    'PRIVMSG ' . $this->source . ' :' . $msg
-            );
+            $message = 'PRIVMSG ' . $this->source . ' :' . $msg;
+            $this->connection->sendData($message);
+            $this->bot->log($message, 'COMMAND');
         }
-	
-	/**
-	 * Get help for the command being run.
-	 */
+
         public function getHelp() {
            if (!empty($this->help))
                 return array($this->help, $this->usage);
         }
         
-        /**
-         * Check if the current commands requires verification.
-         */
         public function needsVerification()
         {
                 return !empty($this->verify);
@@ -216,8 +207,6 @@
          * This method is called if the command get's executed.
          */
         public function command() {
-            echo 'fail';
-            flush();
             throw new Exception( 'You have to overwrite the "command" method and the "executeCommand". Call the parent "executeCommand" and execute your custom "command".' );
         }
 
@@ -267,7 +256,7 @@
          */
         protected function fetch($uri) {
 
-            $this->bot->log("Fetching from URI: " . $uri);
+            $this->bot->log("Fetching data from URI: " . $uri);
 
             // create curl resource
             $ch = curl_init();
@@ -275,7 +264,7 @@
             // set url
             curl_setopt($ch, CURLOPT_URL, $uri);
             
-            // Set a user agent. Some sites require it (e.g. GitHub API).
+            // user agent.
             curl_setopt($ch, CURLOPT_USERAGENT, 'WildPHP/IRCBot');
 
             //return the transfer as a string
@@ -288,7 +277,7 @@
             // close curl resource to free up system resources
             curl_close($ch);
 
-            $this->bot->log("Data fetched: " . $output);
+            //$this->bot->log("Data fetched: " . $output);
 
             return $output;
         }

--- a/Classes/Library/IRC/Command/Base.php
+++ b/Classes/Library/IRC/Command/Base.php
@@ -37,7 +37,7 @@
 
         /**
          * Reference to the IRC Bot
-         * @var \Lirary\IRC\Bot
+         * @var \Library\IRC\Bot
          */
         protected $bot = null;
 

--- a/Classes/Library/IRC/Command/Manager.php
+++ b/Classes/Library/IRC/Command/Manager.php
@@ -1,0 +1,54 @@
+<?php
+namespace Library\IRC\Command;
+
+// This is a manager folks, not a class to toy around with. Non-expandable!
+final class Manager {
+	private $bot = null;
+	
+	/**
+	 * The list of commands.
+	 * @var array
+	 */
+	public $commands = array();
+	
+	public function __construct(\Library\IRC\Bot $bot)
+	{
+		$this->bot = $bot;
+	}
+	
+	/**
+	 * Adds a single command to the bot.
+	 *
+	 * @param IRCCommand $command The command to add.
+	 * @author Daniel Siepmann <coding.layne@me.com>
+	 */
+	public function addCommand(\Library\IRC\Command\Base $command)
+	{
+		$commandName = \Library\FunctionCollection::getClassName($command);
+		$command->setIRCConnection($this->bot->getConnection());
+		$command->setIRCBot($this->bot);
+		$this->commands[$commandName] = $command;
+		$this->bot->log( 'The following Command was added to the Bot: "' . $commandName . '".', 'INFO' );
+	}
+	
+	public function listCommands()
+	{
+		return $this->commands;
+	}
+	
+	public function commandExists($command)
+	{
+		return array_key_exists($command, $this->commands);
+	}
+	
+
+	public function executeCommand( $source, $commandName, array $arguments, $data ) {
+		// Execute command:
+		$command = $this->commands[$commandName];
+		/** @var $command IRCCommand */
+		$command->executeCommand( $arguments, $source, $data );
+	}
+}
+
+
+?>

--- a/Classes/Library/IRC/Connection.php
+++ b/Classes/Library/IRC/Connection.php
@@ -48,7 +48,7 @@
          * Interaction with the server.
          * For example, send commands or some other data to the server.
          *
-         * @return boolean FALSE on error.
+         * @return boolean|int the number of bytes written, or FALSE on error.
          */
         public function sendData( $data );
 

--- a/Classes/Library/IRC/Connection/Socket.php
+++ b/Classes/Library/IRC/Connection/Socket.php
@@ -119,7 +119,7 @@
          * Interaction with the server.
          * For example, send commands or some other data to the server.
          *
-         * @return int|boolean the number of bytes written, or FALSE on error.
+         * @return boolean|int the number of bytes written, or FALSE on error.
          */
         public function sendData( $data ) {
             return fwrite( $this->socket, $data . "\r\n" );

--- a/Classes/Library/IRC/Connection/Socket.php
+++ b/Classes/Library/IRC/Connection/Socket.php
@@ -44,7 +44,7 @@
 
         /**
          * The TCP/IP connection.
-         * @var type
+         * @var resource
          */
         private $socket;
         
@@ -88,10 +88,7 @@
             // Open a connection.
             $this->socket = fsockopen($server, $port);
             if (!$this->isConnected())
-            {
                 throw new Exception('Unable to connect to server via fsockopen with server: "' . $server . '" and port: "' . $port . '".');
-                return;
-            }
           
             if (!empty($pass))
                 $this->sendData('PASS ' . $pass);

--- a/Classes/Library/IRC/Listener/Base.php
+++ b/Classes/Library/IRC/Listener/Base.php
@@ -57,38 +57,4 @@ abstract class Base
 
         return array_map($func, $args);
     }
-    
-    /**
-     * Fetches data from $uri
-     *
-     * @param string $uri
-     * @return string
-     */
-    protected function fetch($uri) {
-
-	$this->bot->log("Fetching data from URI: " . $uri);
-
-	// create curl resource
-	$ch = curl_init();
-
-	// set url
-	curl_setopt($ch, CURLOPT_URL, $uri);
-	
-	// user agent.
-	curl_setopt($ch, CURLOPT_USERAGENT, 'WildPHP/IRCBot');
-
-	//return the transfer as a string
-	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-	curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1);
-
-	// $output contains the output string
-	$output = curl_exec($ch);
-
-	// close curl resource to free up system resources
-	curl_close($ch);
-
-	//$this->bot->log("Data fetched: " . $output);
-
-	return $output;
-    }
 }

--- a/Classes/Library/IRC/Listener/Base.php
+++ b/Classes/Library/IRC/Listener/Base.php
@@ -23,9 +23,9 @@ abstract class Base
      * @param string $msg
      */
     protected function say($msg, $source) {
-        $this->connection->sendData(
-                'PRIVMSG ' . $source . ' :' . $msg
-        );
+            $message = 'PRIVMSG ' . $source . ' :' . $msg;
+            $this->connection->sendData($message);
+            $this->bot->log($message, 'COMMAND');
     }
 
     /**
@@ -57,37 +57,4 @@ abstract class Base
 
         return array_map($func, $args);
     }
-	/**
-	 * Fetches data from $uri
-	 *
-	 * @param string $uri
-	 * @return string
-	 */
-	protected function fetch($uri) {
-
-		$this->bot->log("Fetching from URI: " . $uri);
-
-		// create curl resource
-		$ch = curl_init();
-
-		// set url
-		curl_setopt($ch, CURLOPT_URL, $uri);
-		
-		// Set a user agent. Some sites require it (e.g. GitHub API).
-		curl_setopt($ch, CURLOPT_USERAGENT, 'WildPHP/IRCBot');
-
-		//return the transfer as a string
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1);
-
-		// $output contains the output string
-		$output = curl_exec($ch);
-
-		// close curl resource to free up system resources
-		curl_close($ch);
-
-		$this->bot->log("Data fetched: " . $output);
-
-		return $output;
-	}
 }

--- a/Classes/Library/IRC/Listener/Base.php
+++ b/Classes/Library/IRC/Listener/Base.php
@@ -32,7 +32,7 @@ abstract class Base
      * Set's the IRC Connection, so we can use it to send data to the server.
      * @param \Library\IRC\Connection $ircConnection
      */
-    public function setIRCConnection( \Library\IRC\Connection $ircConnection ) {
+    public function setIRCConnection(\Library\IRC\Connection $ircConnection) {
         $this->connection = $ircConnection;
     }
 
@@ -56,5 +56,39 @@ abstract class Base
         };
 
         return array_map($func, $args);
+    }
+    
+    /**
+     * Fetches data from $uri
+     *
+     * @param string $uri
+     * @return string
+     */
+    protected function fetch($uri) {
+
+	$this->bot->log("Fetching data from URI: " . $uri);
+
+	// create curl resource
+	$ch = curl_init();
+
+	// set url
+	curl_setopt($ch, CURLOPT_URL, $uri);
+	
+	// user agent.
+	curl_setopt($ch, CURLOPT_USERAGENT, 'WildPHP/IRCBot');
+
+	//return the transfer as a string
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+	curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1);
+
+	// $output contains the output string
+	$output = curl_exec($ch);
+
+	// close curl resource to free up system resources
+	curl_close($ch);
+
+	//$this->bot->log("Data fetched: " . $output);
+
+	return $output;
     }
 }

--- a/Classes/Library/IRC/Listener/Manager.php
+++ b/Classes/Library/IRC/Listener/Manager.php
@@ -1,0 +1,70 @@
+<?php
+namespace Library\IRC\Listener;
+
+// This is a manager folks, not a class to toy around with. Non-expandable!
+final class Manager {
+	private $bot = null;
+	
+	/**
+	 * The list of commands.
+	 * @var array
+	 */
+	private $listeners = array();
+	
+	public function __construct(\Library\IRC\Bot $bot)
+	{
+		$this->bot = $bot;
+	}
+	
+	/**
+	 * Adds a single command to the bot.
+	 *
+	 * @param IRCCommand $command The command to add.
+	 * @author Daniel Siepmann <coding.layne@me.com>
+	 */
+	public function addListener(\Library\IRC\Listener\Base $listener)
+	{
+		$listenerName = \Library\FunctionCollection::getClassName($listener);
+		$listener->setIRCConnection($this->bot->getConnection());
+		$listener->setIRCBot($this->bot);
+		$this->listeners[$listenerName] = $listener;
+		$this->bot->log( 'The following Listener was added to the Bot: "' . $listenerName . '".', 'INFO' );
+	}
+	
+	public function listListeners()
+	{
+		return $this->listeners;
+	}
+	
+	public function listenerExists($listener)
+	{
+		return array_key_exists($listener, $this->listeners);
+	}
+	
+
+	public function listenerHook(array $arguments, $data ) {
+		/* @var $listener \Library\IRC\Listener\Base */
+		foreach ($this->listeners as $listener) {
+			if (method_exists($listener, 'getKeywords') && is_array($listener->getKeywords())) {
+				foreach ($listener->getKeywords() as $keyword) {
+					if ($keyword === $arguments[1]) {
+						$this->bot->log('Running listener, command detected: ' . $keyword, 'LISTENER');
+						$listener->execute( $data );
+					}
+				}
+			}
+			if (method_exists($listener, 'getMessageKeywords') && is_array($listener->getMessageKeywords())) {
+				foreach ($listener->getMessageKeywords() as $keyword) {
+					if (stripos($data, $keyword)) {
+						$this->bot->log('Running listener, message contains "' . $keyword . '"', 'LISTENER');
+						$listener->execute( $data );
+						
+					}
+				}
+			}
+		}
+	}
+}
+
+
+?>

--- a/Classes/Library/IRC/Log.php
+++ b/Classes/Library/IRC/Log.php
@@ -16,7 +16,7 @@ class Log
 	 * @var object
 	 */
 	protected $bot;
-
+	
 	/**
 	 * Use a buffer to temporarily store data in. Useful on systems with slow disk access.
 	 * @var bool

--- a/Classes/Listener/Joins.php
+++ b/Classes/Listener/Joins.php
@@ -15,30 +15,10 @@ class Joins extends \Library\IRC\Listener\Base {
      */
     public function execute($data) {
         $args = $this->getArguments($data);
+        $user = \Library\FunctionCollection::getUserNickName($args[0]);
 
-        $this->say($this->getUserNickName($args[0]) . ", welcome to channel " . $args[2] . ". Try following commands: " . $this->getCommandsName(), $args[2]);
-    }
-
-    private function getCommandsName() {
-        $commands = $this->bot->getCommands();
-
-        $names = array();
-        /* @var $command \Library\IRC\Command\Base */
-        foreach ($commands as $name => $command) {
-            $names[] = $this->bot->getCommandPrefix() . $name;
-        }
-
-        return implode(", ", $names);
-    }
-
-    private function getUserNickName($data) {
-        $result = preg_match('/:([a-zA-Z0-9_]+)!/', $data, $matches);
-
-        if ($result !== false) {
-            return $matches[1];
-        }
-
-        return false;
+        if ($user != 'FatalException')
+		$this->say('Welcome ' . $user . '!', $args[2]);
     }
 
     /**

--- a/Classes/Listener/Youtube.php
+++ b/Classes/Listener/Youtube.php
@@ -31,7 +31,7 @@ class Youtube extends \Library\IRC\Listener\Base {
 		if (isset($matches[0]))
 		{
 			$ytApi		= sprintf($this->apiUri, $matches[0]);
-			$Ytdata	= $this->fetch($ytApi);
+			$Ytdata	= \Library\FunctionCollection::fetch($ytApi);
 			preg_match("/(?<=<title type=\'text\'>).*(?=<\/title>)/", $Ytdata, $ytTitle); 
 			return $ytTitle[0];
 		}

--- a/config.php
+++ b/config.php
@@ -5,6 +5,7 @@ return array(
     'name'     => 'phpbot',
     'password' => '',
     'nick'     => 'phpbot',
+    'nickserv' => 'NickServ', // What is the nickname registration service on this server?
     'channels' => array(
         '#wildphp',
     ),


### PR DESCRIPTION
Changes up to now:
- Split command system from Bot.php into a Command/Manager class
- Split connection system from Bot.php into Socket.php
- Split various static functions into FunctionCollection
- The bot now waits for NickServ authentication before joining channels
- NickServ is no longer hardcoded
- Command prefix moved out of main() into __construct
- __construct now actually does something (removed all setters from phpbot404.php
- Merge PR #4
- Split listener system from Bot.php into a Listener/Manager class
- With that, remove the listener detection code from Bot.php and put it into Listener/Manager class; hook it into the main loop
- Fix a bug where hosts without ~ would not be detected
- Fix a bug where the Autoloader would throw an exception when throwing an exception

Signed-off-by: Yoshi2889 <rick.2889@gmail.com>