### PR TITLE
Fix undefined variable in docblock

### DIFF
--- a/lib/WildPHP/EventManager.php
+++ b/lib/WildPHP/EventManager.php
@@ -92,7 +92,7 @@ class EventManager
 	/**
 	 * Hook into an event.
 	 * @param string $event The event to hook into.
-	 * @param mixed $hook The hook to insert, as a function name. Pass as array($class, 'function') if in a class.
+	 * @param mixed $listener The hook to insert, as a function name. Pass as array($class, 'function') if in a class.
 	 * @return bool Boolean determining if adding the hook succeeded.
 	 */
 	public function registerEventListener($event, $listener, $priority = 3)


### PR DESCRIPTION
Should make Scrutinizer-CI somewhat more happy. $hook was renamed to $listener in 15d30892abf226b64aa85309287a7737f761b85c, leaving the rest of the $listener as it is because afaik it doesn't really need a change (please correct me as needed).