### PR TITLE
.travis.yml: fast_finish & allow nightly to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,9 @@ script:
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php:
+      - nightly


### PR DESCRIPTION
fast_finish makes the build report as failed when one build (which is not allowed to fail) fails, but the other jobs still continue running.

I think you possibly want to allow php nightly to fail as it can have php nightly bugs. Tests for it are still ran anyway.

I am not sure on php 7, but I think you might want to allow it to fail too.